### PR TITLE
Refactor existing records getter

### DIFF
--- a/addon/-private/resources/array-map.ts
+++ b/addon/-private/resources/array-map.ts
@@ -19,7 +19,7 @@ export class TrackedArrayMap<Element extends object, MappedTo> extends Lifecycle
   #map = new WeakMap<Element, MappedTo>();
 
   // @private
-  get #records(): Element[] {
+  get _records(): Element[] {
     return this.args.positional[0];
   }
 
@@ -30,12 +30,12 @@ export class TrackedArrayMap<Element extends object, MappedTo> extends Lifecycle
 
   // @public
   get length() {
-    return this.#records.length;
+    return this._records.length;
   }
 
   // @private
   at(i: number) {
-    let record = this.#records[i];
+    let record = this._records[i];
     let value = this.#map.get(record);
 
     if (!value) {

--- a/addon/-private/resources/array-map.ts
+++ b/addon/-private/resources/array-map.ts
@@ -19,18 +19,23 @@ export class TrackedArrayMap<Element extends object, MappedTo> extends Lifecycle
   #map = new WeakMap<Element, MappedTo>();
 
   // @private
-  get records(): Element[] {
+  get #records(): Element[] {
     return this.args.positional[0];
+  }
+
+  // public
+  get records() {
+    return [...this];
   }
 
   // @public
   get length() {
-    return this.records.length;
+    return this.#records.length;
   }
 
   // @private
   at(i: number) {
-    let record = this.records[i];
+    let record = this.#records[i];
     let value = this.#map.get(record);
 
     if (!value) {

--- a/addon/-private/resources/array-map.ts
+++ b/addon/-private/resources/array-map.ts
@@ -23,7 +23,7 @@ export class TrackedArrayMap<Element extends object, MappedTo> extends Lifecycle
     return this.args.positional[0];
   }
 
-  // public
+  // @public
   get records() {
     return [...this];
   }

--- a/tests/js-test.ts
+++ b/tests/js-test.ts
@@ -59,6 +59,9 @@ module('useArrayMap', function (hooks) {
     // this tests the iterator
     currentStuff = [...instance.stuff];
 
+    assert.ok(instance.stuff.records[0] instanceof Wrapper, 'mappedRecords id:1');
+    assert.ok(instance.stuff.records[1] instanceof Wrapper, 'mappedRecords id:2');
+
     assert.strictEqual(currentStuff[0].record, first, 'object equality retained');
     assert.strictEqual(currentStuff[1].record, second, 'object equality retained');
 


### PR DESCRIPTION
Refactor existing records getter to be private and keep the same logic.  Add a new public getter for 'records' with logic to return the mapped array